### PR TITLE
fix: update list policies

### DIFF
--- a/src/lib/v2/policies-v2.spec.ts
+++ b/src/lib/v2/policies-v2.spec.ts
@@ -5,35 +5,37 @@ describe('PoliciesV2', () => {
         jest.clearAllMocks()
     })
 
-    it('lists policies and auto paginates', async () => {
+    it('lists policies from items response', async () => {
         const http = {
-            post: jest
-                .fn()
-                .mockResolvedValueOnce({
-                    data: {
-                        items: [{ id: 'policy-1' }],
-                        metadata: { page: 1, per_page: 1, page_count: 2 },
-                    },
-                })
-                .mockResolvedValueOnce({
-                    data: {
-                        items: [{ id: 'policy-2' }],
-                        metadata: { page: 2, per_page: 1, page_count: 2 },
-                    },
-                }),
+            post: jest.fn().mockResolvedValue({
+                data: {
+                    items: [{ id: 'policy-1' }, { id: 'policy-2' }],
+                },
+            }),
         }
 
         const policies = new PoliciesV2(http as never)
-        const result = await policies.list({ perPage: 1 })
+        const result = await policies.list()
 
         expect(result).toEqual([{ id: 'policy-1' }, { id: 'policy-2' }])
-        expect(http.post).toHaveBeenNthCalledWith(1, '/oa/policies/query', {
-            page: 1,
-            per_page: 1,
-        })
-        expect(http.post).toHaveBeenNthCalledWith(2, '/oa/policies/query', {
-            page: 2,
-            per_page: 1,
+        expect(http.post).toHaveBeenCalledWith('/oa/policies/query', {})
+    })
+
+    it('lists policies with policy filter', async () => {
+        const http = {
+            post: jest.fn().mockResolvedValue({
+                data: {
+                    items: [{ id: 'policy-1' }],
+                },
+            }),
+        }
+
+        const policies = new PoliciesV2(http as never)
+        const result = await policies.list(['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'])
+
+        expect(result).toEqual([{ id: 'policy-1' }])
+        expect(http.post).toHaveBeenCalledWith('/oa/policies/query', {
+            policies: ['aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'],
         })
     })
 

--- a/src/lib/v2/policies-v2.ts
+++ b/src/lib/v2/policies-v2.ts
@@ -1,28 +1,19 @@
 import { AxiosInstance } from 'axios'
-import { PaginationV2 } from './pagination-v2'
-import {
-    CreatePolicyRequest,
-    PoliciesListResponse,
-    V2Policy,
-    V2ListOptions,
-    V2ListRequestBody,
-} from './v2.types'
+import { CreatePolicyRequest, PoliciesListResponse, V2Policy } from './v2.types'
 
 export class PoliciesV2 {
     constructor(private readonly http: AxiosInstance) {}
 
-    async list(options?: V2ListOptions): Promise<V2Policy[]> {
-        const baseRequest: V2ListRequestBody = {}
+    async list(policies?: string[]): Promise<V2Policy[]> {
+        const requestBody = policies ? { policies } : {}
+        const response = await this.http.post('/oa/policies/query', requestBody)
+        const responseData = response.data as PoliciesListResponse | V2Policy[]
 
-        return PaginationV2.fetchItems<V2Policy>(async ({ page, per_page }) => {
-            const requestBody = PaginationV2.buildRequestBody(baseRequest, {
-                ...options,
-                page,
-                perPage: per_page,
-            })
-            const response = await this.http.post('/oa/policies/query', requestBody)
-            return response.data as PoliciesListResponse
-        }, options)
+        if (Array.isArray(responseData)) {
+            return responseData
+        }
+
+        return responseData.items ?? []
     }
 
     async create(name: string): Promise<V2Policy> {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `PoliciesV2.list` request/response semantics by removing auto-pagination and `V2ListOptions`, which may break callers relying on paging/sorting and could change result sizes returned from the API.
> 
> **Overview**
> Updates `PoliciesV2.list` to **stop using `PaginationV2` auto-pagination** and instead issue a single `POST /oa/policies/query`, returning either a raw array response or `data.items` (defaulting to `[]`).
> 
> The list API now optionally accepts a `policies: string[]` filter (instead of `V2ListOptions`), and the unit tests are updated to reflect the new single-call behavior and add coverage for the policy filter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76108410cc1d24e4a4fe42916e8aae0ce6af0eb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->